### PR TITLE
cor: implemented function to get big endian 32 from a string

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -559,6 +559,15 @@ cc_oci_enable_networking (void)
 	return enable;
 }
 
+/*!
+ * Convert the value stored in buffer to little endian
+ *
+ * \param buf Buffer storing the big endian value
+ */
+guint32 cc_oci_get_big_endian_32(char *buf) {
+	return (guint32)(buf[0] >> 24 | buf[1] >> 16 | buf[2] >> 8 | buf[3]);
+}
+
 #ifdef DEBUG
 static gboolean
 cc_oci_node_dump_aux(GNode* node, gpointer data) {

--- a/src/util.h
+++ b/src/util.h
@@ -87,5 +87,6 @@ int cc_oci_get_signum (const gchar *signame);
 gchar *cc_oci_resolve_path (const gchar *path);
 gboolean cc_oci_fd_set_cloexec (int fd);
 gboolean cc_oci_enable_networking (void);
+guint32 cc_oci_get_big_endian_32(char *buf);
 
 #endif /* _CC_OCI_UTIL_H */


### PR DESCRIPTION
This patch adds a function to get big endian 32
from a string, this function will be useful to process
first 8 bits of cc-proxy' response

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>
Signed-off-by: Julio Montes <julio.montes@intel.com>