### PR TITLE
state: Add process oci node to state

### DIFF
--- a/src/oci.c
+++ b/src/oci.c
@@ -1800,6 +1800,11 @@ cc_oci_config_update (struct cc_oci_config *config,
 		state->mounts = NULL;
 	}
 
+	if(state->process) {
+		config->oci.process = *state->process;
+		state->process = NULL;
+	}
+
 	if (state->console) {
 		config->console = state->console;
 		state->console = NULL;
@@ -1826,4 +1831,48 @@ cc_oci_config_update (struct cc_oci_config *config,
 	}
 
 	return true;
+}
+
+/*!
+* Convert the config process to a JSON object.
+*
+* \param config \ref cc_oci_config.
+*
+* \return \c JsonObject on success, else \c NULL.
+*/
+	JsonObject *
+cc_oci_process_to_json(const struct oci_cfg_process *process)
+{
+	JsonObject *json_process = NULL;
+	JsonObject *user         = NULL;
+	JsonArray  *args         = NULL;
+	JsonArray  *envs         = NULL;
+
+	if (! (process && process->args && process->cwd[0])) {
+		goto out;
+	}
+
+	json_process = json_object_new ();
+	user         = json_object_new ();
+	args         = json_array_new ();
+	envs         = json_array_new ();
+
+
+	for (gchar** p = process->args; p && *p; p++) {
+		json_array_add_string_element (args, *p);
+	}
+
+	for (gchar** p = process->env; p && *p; p++) {
+		json_array_add_string_element (envs, *p);
+	}
+
+	json_object_set_string_member (json_process, "cwd", process->cwd);
+	json_object_set_boolean_member (json_process, "terminal",
+			process->terminal);
+	json_object_set_object_member (json_process, "user", user);
+	json_object_set_array_member (json_process, "args", args);
+	json_object_set_array_member (json_process, "env", envs);
+
+out:
+	return json_process;
 }

--- a/src/oci.h
+++ b/src/oci.h
@@ -43,6 +43,8 @@
 
 #include <glib.h>
 #include <gio/gio.h>
+#include <json-glib/json-glib.h>
+
 
 #ifndef CLONE_NEWCGROUP
 #define CLONE_NEWCGROUP 0x02000000
@@ -413,6 +415,9 @@ struct oci_state {
 
 	struct cc_oci_vm_cfg *vm;
 	struct cc_proxy      *proxy;
+
+	/* Needed by start to create a new container workload  */
+	struct oci_cfg_process *process;
 };
 
 /** clr-specific state fields. */
@@ -579,5 +584,8 @@ gboolean cc_oci_config_update (struct cc_oci_config *config,
 		struct oci_state *state);
 gboolean
 cc_oci_create_container_networking_workload (struct cc_oci_config *config);
+
+JsonObject *
+cc_oci_process_to_json(const struct oci_cfg_process *process);
 
 #endif /* _CC_OCI_H */

--- a/src/state.c
+++ b/src/state.c
@@ -39,6 +39,7 @@
 #include "annotation.h"
 #include "json.h"
 #include "config.h"
+#include "spec_handler.h"
 
 #define update_subelements_and_strdup(node, data, member) \
 	if (node && node->data) { \
@@ -61,6 +62,7 @@ static void handle_state_console_section(GNode*, struct handler_data*);
 static void handle_state_vm_section(GNode*, struct handler_data*);
 static void handle_state_proxy_section(GNode*, struct handler_data*);
 static void handle_state_annotations_section(GNode*, struct handler_data*);
+static void handle_state_process_section(GNode* node, struct handler_data* data);
 
 /*! Used to handle each section in \ref CC_OCI_STATE_FILE. */
 static struct state_handler {
@@ -437,6 +439,24 @@ handle_state_annotations_section(GNode* node, struct handler_data* data)
 }
 
 /*!
+* handler for process section usig oci spec handlers
+*
+* \param node \c GNode.
+* \param data \ref handler_data.
+*/
+static void
+handle_state_process_section(GNode* node, struct handler_data* data)
+{
+	struct cc_oci_config config;
+        g_assert(data->state);
+	data->state->process = g_new0(struct oci_cfg_process, 1);
+
+	process_spec_handler.handle_section(node, &config);
+
+        *data->state->process = config.oci.process;
+}
+
+/*!
  * process all sections in state.json using the right section handler
  *
  * \param node \c GNode.
@@ -458,6 +478,11 @@ handle_state_sections(GNode* node, struct oci_state* state) {
 				(GNodeForeachFunc)handler->handle_section, &data);
 			return;
 		}
+	}
+	/* Handle "process" node using oci spec handlers */
+	if (g_strcmp0(node->data, "process") == 0) {
+		handle_state_process_section(node, &data);
+		return;
 	}
 
 	g_critical("handler not found %s", (char*)node->data);
@@ -643,6 +668,7 @@ cc_oci_state_file_create (struct cc_oci_config *config,
 	JsonObject  *proxy = NULL;
 	JsonObject  *annotation_obj = NULL;
 	JsonArray   *mounts = NULL;
+	JsonObject  *process = NULL;
 	gchar       *str = NULL;
 	gsize        str_len = 0;
 	GError      *err = NULL;
@@ -730,6 +756,17 @@ cc_oci_state_file_create (struct cc_oci_config *config,
 	}
 
 	json_object_set_array_member (obj, "mounts", mounts);
+
+	/* Add an process object to allow "start" command  what workload
+	 * will be used
+	 */
+	process = cc_oci_process_to_json(&config->oci.process);
+	if (! process) {
+		g_critical ("failed to create state file, no process information");
+		goto out;
+	}
+
+	json_object_set_object_member (obj, "process", process);
 
 	/* Add an object containing details of the console device being
 	 * used.

--- a/tests/oci_test.c
+++ b/tests/oci_test.c
@@ -1023,10 +1023,13 @@ START_TEST(test_cc_oci_kill) {
 		G_SPAWN_STDOUT_TO_DEV_NULL |
 		G_SPAWN_STDERR_TO_DEV_NULL |
 		G_SPAWN_DO_NOT_REAP_CHILD);
-	gchar *args[] = { "sleep", "999", NULL };
 
 	config = cc_oci_config_create ();
 	ck_assert (config);
+
+	config->oci.process.args = g_strsplit("sleep 999", " ", -1);
+	snprintf(config->oci.process.cwd, sizeof(config->oci.process.cwd),
+				"%s", "/working_directory");
 
 	config_tmp = cc_oci_config_create ();
 	ck_assert (config_tmp);
@@ -1046,7 +1049,7 @@ START_TEST(test_cc_oci_kill) {
 
 	/* start a fake process */
 	ret = g_spawn_async (NULL, /* wd */
-			args,
+			config->oci.process.args,
 			NULL, /* env */
 			flags,
 			NULL, /* child setup */

--- a/tests/state_test.c
+++ b/tests/state_test.c
@@ -219,6 +219,14 @@ START_TEST(test_cc_oci_state_file_create) {
         config->oci.annotations =
 		g_slist_append(config->oci.annotations, a);
 
+	/* config->oci.process not set */
+	ck_assert(! cc_oci_state_file_create (config, timestamp));
+
+	snprintf(config->oci.process.cwd, sizeof(config->oci.process.cwd),
+				"%s", "/working_directory");
+
+	config->oci.process.args = g_strsplit("/bin/echo test", " ", -1);
+
 	/* config->vm not set */
 	ck_assert(! cc_oci_state_file_create (config, timestamp));
 

--- a/tests/test_common.c
+++ b/tests/test_common.c
@@ -231,6 +231,21 @@ test_helper_create_state_file (const char *name,
 		return false;
 	}
 
+	/* config->process not set */
+	if (cc_oci_state_file_create (config, timestamp)) {
+		fprintf (stderr, "ERROR: cc_oci_state_file_create "
+				"worked unexpectedly for vm %s (no config->process)\n", name);
+		return false;
+	}
+
+	if (snprintf(config->oci.process.cwd, sizeof(config->oci.process.cwd),
+				"%s", "/working_directory") < 0) {
+		fprintf (stderr, "ERROR: cc_oci_state_file_create "
+				"failed to copy process cwd for vm %s", name);
+	}
+
+	config->oci.process.args = g_strsplit("/bin/echo test", " ", -1);
+
 	/* config->vm not set */
 	if (cc_oci_state_file_create (config, timestamp)) {
 		fprintf (stderr, "ERROR: cc_oci_state_file_create "


### PR DESCRIPTION
This patch adds process node from oci config.json.
Thil will allow to use process information by start command.
The start command will used to create a NEWCONTAINER workload
for hyperstart.

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>
Signed-off-by: Julio Montes <julio.montes@intel.com>